### PR TITLE
[Logging] Add brackets around timestamp and log level

### DIFF
--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -338,7 +338,7 @@ const logging = {
     return {
       level,
       logger: (level, message) =>
-        console.log(`${global.Date.now()} ${level.toUpperCase()} ${message}`)
+        console.log(`[${global.Date.now()}] [${level.toUpperCase()}] ${message}`)
     }
   }
 }


### PR DESCRIPTION
This changes the `console` logger output from this:
```
1680156769966 INFO Routing driver 0 created for server address localhost:7687
1680156769969 INFO Routing table is stale for database: "null" and access mode: "READ": RoutingTable[database=default database, expirationTime=0, currentTime=1680156769969, routers=[], readers=[], writers=[]]
1680156769989 INFO Updated routing table RoutingTable[database=neo4j, expirationTime=1680157069987, currentTime=1680156769989, routers=[localhost:7687], readers=[localhost:7687], writers=[localhost:7687]]
The query `MATCH (p:Person {age: $age}) RETURN p.name AS name` returned 0 records in 2 ms.
1680156770005 INFO Driver 0 closing
```

to this:
```
[1680158258349] [INFO] Routing driver 0 created for server address localhost:7687
[1680158258352] [INFO] Routing table is stale for database: "null" and access mode: "READ": RoutingTable[database=default database, expirationTime=0, currentTime=1680158258352, routers=[], readers=[], writers=[]]
[1680158258372] [INFO] Updated routing table RoutingTable[database=neo4j, expirationTime=1680158558371, currentTime=1680158258372, routers=[localhost:7687], readers=[localhost:7687], writers=[localhost:7687]]
The query `MATCH (p:Person {age: $age}) RETURN p.name AS name` returned 0 records in 2 ms.
[1680158258392] [INFO] Driver 0 closing
```

which I personally find easier to parse, and I think is more in line with other logs I've seen.

PS. I also looked into turning the timestamp into a proper date. `.toISOString` on a `new Date(Date.now())` seemed promising, except that js seems unaware of the local timezone so it would become a log of wrong times :man_shrugging: 